### PR TITLE
Update README.md for R package link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ conda install -c conda-forge fastf1
 
 ### Third-party packages
 
-- R package that wraps FastF1: https://github.com/SCasanova/f1dataR
+- R package that wraps FastF1: https://cran.r-project.org/package=f1dataR
 
 Third-party packages are not directly related to the FastF1 project. Questions 
 and suggestions regarding these packages need to be directed at their 


### PR DESCRIPTION
Change the R package link to CRAN (R language's package repository). The presence on CRAN makes installation easy for R users, and does contain links to the Github page for support.